### PR TITLE
Switch unit end to use transmission_list instead of transmission_source_list

### DIFF
--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -335,7 +335,7 @@ public:
         node.put("unit", transmission.source);
         node.put("unit_alpha", sys->find_unit_tag(transmission.source));
         node.put("start_time", transmission.start_time);
-        node.put("end_time", transmission.start_time);
+        node.put("stop_time", transmission.stop_time);
         node.put("sample_count", transmission.sample_count);
         node.put("spike_count", transmission.spike_count);
         node.put("error_count", transmission.error_count);

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -297,7 +297,7 @@ public:
       node.put("freq", call->get_freq());
       node.put("talkgroup", talkgroup_num);
       node.put("talkgroup_patches", patch_string);
-      node.put("talkgroup_alpha", call->get_talkgroup_tag());
+      node.put("talkgroup_alpha_tag", call->get_talkgroup_tag());
       node.put("talkgroup_patches", patch_string);
       node.put("encrypted", call->get_encrypted());
       send_object(node, "call", "call", this->unit_topic+"/"+short_name);

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -85,7 +85,15 @@ public:
     for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it)
     {
       System *system = *it;
-      nodes.push_back(std::make_pair("", system->get_stats_current(timeDiff)));
+      boost::property_tree::ptree system_node;
+      system_node.put("id", system->get_sys_num());
+      system_node.put("short_name", system->get_short_name());
+      system_node.put("decode_rate", system->get_message_count() / timeDiff);
+      
+      // So we don't break anyone.
+      system_node.put("decoderate", system->get_message_count() / timeDiff);
+
+      nodes.push_back(std::make_pair("", system_node));
     }
     
     /**

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -293,9 +293,12 @@ public:
       node.put("system", short_name );
       node.put("unit", source_id );
       node.put("unit_alpha", call->get_system()->find_unit_tag(source_id));
+      node.put("start_time", call->get_start_time());
+      node.put("freq", call->get_freq());
       node.put("talkgroup", talkgroup_num);
       node.put("talkgroup_patches", patch_string);
       node.put("talkgroup_alpha", call->get_talkgroup_tag());
+      node.put("talkgroup_patches", patch_string);
       node.put("encrypted", call->get_encrypted());
       send_object(node, "call", "call", this->unit_topic+"/"+short_name);
     }
@@ -343,7 +346,6 @@ public:
         node.put("call_filename", call_info.filename);
         node.put("position", total_length);
         node.put("talkgroup", call_info.talkgroup);
-        node.put("talkgroup_alpha", call_info.talkgroup_alpha_tag);
         node.put("talkgroup_alpha_tag",call_info.talkgroup_alpha_tag);
         node.put("talkgroup_description",call_info.talkgroup_description);
         node.put("talkgroup_group",call_info.talkgroup_group);

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -85,15 +85,7 @@ public:
     for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it)
     {
       System *system = *it;
-      boost::property_tree::ptree system_node;
-      system_node.put("id", system->get_sys_num());
-      system_node.put("short_name", system->get_short_name());
-      system_node.put("decode_rate", system->get_message_count() / timeDiff);
-      
-      // So we don't break anyone.
-      system_node.put("decoderate", system->get_message_count() / timeDiff);
-
-      nodes.push_back(std::make_pair("", system_node));
+      nodes.push_back(std::make_pair("", system->get_stats_current(timeDiff)));
     }
     
     /**


### PR DESCRIPTION
I tried to rename stuff to be more consistent, which will break existing users of those variables. I suck. Sorry.