### PR TITLE
Client ID Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ sudo make install
 
 | Key       | Required | Default Value | Type   | Description                                                  |
 | --------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
+| clientname|          | tr-status     | string | This is the optional client id to send to MQTT |
 | broker    |    ✓     |   tcp://localhost:1883            | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
 | topic     |    ✓     |               | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages. |
 | unit_topic|          |               | string | Optional field to enable reporting of unit stats over MQTT. |
@@ -63,6 +64,7 @@ See the included [config.json](./config.json) as an example of how to load this 
     "plugins": [
     {
         "name": "MQTT Status",
+        "clientname": "tr_status",
         "library": "libmqtt_status_plugin.so",
         "broker": "tcp://io.adafruit.com:1883",
         "topic": "robotastic/feeds",

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ sudo make install
 
 ## Configure
 
-| Key       | Required | Default Value | Type   | Description                                                  |
-| --------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
-| clientname|          | tr-status     | string | This is the optional client id to send to MQTT |
-| broker    |    ✓     |   tcp://localhost:1883            | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
-| topic     |    ✓     |               | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages. |
-| unit_topic|          |               | string | Optional field to enable reporting of unit stats over MQTT. |
-| username  |          |               | string | If a username is required for the broker, add it here. |
-| password  |          |               | string | If a password is required for the broker, add it here. |
-| refresh   |          |        60     | int    | Recorders and configs are normally only sent at startup, this sets the interval this information is refreshed. A value of -1 will disable. |
+| Key        | Required | Default Value | Type   | Description                                                  |
+|------------| :------: | ------------- | ------ | ------------------------------------------------------------ |
+| client_id  |          | tr-status     | string | This is the optional client id to send to MQTT |
+| broker     |    ✓     |   tcp://localhost:1883            | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
+| topic      |    ✓     |               | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages. |
+| unit_topic |          |               | string | Optional field to enable reporting of unit stats over MQTT. |
+| username   |          |               | string | If a username is required for the broker, add it here. |
+| password   |          |               | string | If a password is required for the broker, add it here. |
+| refresh    |          |        60     | int    | Recorders and configs are normally only sent at startup, this sets the interval this information is refreshed. A value of -1 will disable. |
 
 
 ### Plugin Object Example
@@ -64,7 +64,7 @@ See the included [config.json](./config.json) as an example of how to load this 
     "plugins": [
     {
         "name": "MQTT Status",
-        "clientname": "tr_status",
+        "client_id": "tr_status",
         "library": "libmqtt_status_plugin.so",
         "broker": "tcp://io.adafruit.com:1883",
         "topic": "robotastic/feeds",

--- a/config.json
+++ b/config.json
@@ -19,6 +19,7 @@
     "plugins": [
     {
         "name": "MQTT Everything!",
+        "client_id": "tr-status",
         "library": "libmqtt_status_plugin.so",
         "broker": "tcp://io.adafruit.com:1883",
         "topic": "robotastic/feeds",

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -31,7 +31,7 @@ class Mqtt_Status : public Plugin_Api, public virtual mqtt::callback, public vir
   std::vector<System *> systems;
   std::vector<Call *> calls;
   Config *config;
-  std::string client_name;
+  std::string client_id;
   std::string mqtt_broker;
   std::string username;
   std::string password;
@@ -561,7 +561,7 @@ public:
     // Open the connection to the destination MQTT server.
     const char *LWT_PAYLOAD = "Last will and testament.";
     // set up access channels to only log interesting things
-    client = new mqtt::async_client(this->mqtt_broker, this->client_name, "./store");
+    client = new mqtt::async_client(this->mqtt_broker, this->client_id, "./store");
 
     mqtt::connect_options connOpts;
 
@@ -701,8 +701,8 @@ public:
     //  Called before init, and passed the Configuration information in the settings file for this plugin.
     this->mqtt_broker = cfg.get<std::string>("broker", "tcp://localhost:1883");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker: " << this->mqtt_broker;
-    this->client_name = cfg.get<std::string>("clientname", "tr-status");
-    BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Client Name: " << this->client_name;
+    this->client_id = cfg.get<std::string>("client_id", "tr-status");
+    BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Client Name: " << this->client_id;
     this->username = cfg.get<std::string>("username", "");
     this->password = cfg.get<std::string>("password", "");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker Username: " << this->username;

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -31,6 +31,7 @@ class Mqtt_Status : public Plugin_Api, public virtual mqtt::callback, public vir
   std::vector<System *> systems;
   std::vector<Call *> calls;
   Config *config;
+  std::string client_name;
   std::string mqtt_broker;
   std::string username;
   std::string password;
@@ -560,7 +561,7 @@ public:
     // Open the connection to the destination MQTT server.
     const char *LWT_PAYLOAD = "Last will and testament.";
     // set up access channels to only log interesting things
-    client = new mqtt::async_client(this->mqtt_broker, "tr-status", "./store");
+    client = new mqtt::async_client(this->mqtt_broker, this->client_name, "./store");
 
     mqtt::connect_options connOpts;
 
@@ -700,6 +701,8 @@ public:
     //  Called before init, and passed the Configuration information in the settings file for this plugin.
     this->mqtt_broker = cfg.get<std::string>("broker", "tcp://localhost:1883");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker: " << this->mqtt_broker;
+    this->client_name = cfg.get<std::string>("clientname", "tr-status");
+    BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Client Name: " << this->client_name;
     this->username = cfg.get<std::string>("username", "");
     this->password = cfg.get<std::string>("password", "");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker Username: " << this->username;


### PR DESCRIPTION
Fix to add a client id to the configuration so multiple instances of trunk recorder will work with one MQTT server. MQTT require clients to have unique ids. 