### PR TITLE
Key rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# Trunk Recorder MQTT Status (and Units!) Plugin <!-- omit from toc --> 
+# Trunk Recorder MQTT Status (and Units!) Plugin <!-- omit from toc -->
 
-This is a plugin for Trunk Recorder that publish the current status over MQTT. External programs can use the MQTT messages to display what is going on.
+This is a plugin for Trunk Recorder that publish the current status over MQTT. External programs can use the MQTT messages to collect and display information on monitored systems.
 
 - [Install](#install)
 - [Configure](#configure)
-- [Plugin Usage Example](#plugin-usage-example)
 - [MQTT Messages](#mqtt-messages)
 - [Mosquitto MQTT Broker](#mosquitto-mqtt-broker)
 - [Docker](#docker)
@@ -15,7 +14,7 @@ This is a plugin for Trunk Recorder that publish the current status over MQTT. E
 
 2. **Install the Paho MQTT C & C++ Libraries**.
 
-- _Install Paho MQTT C_
+&emsp; _Install Paho MQTT C_
 
 ```bash
 git clone https://github.com/eclipse/paho.mqtt.c.git
@@ -26,7 +25,7 @@ sudo cmake --build build/ --target install
 sudo ldconfig
 ```
 
-- _Install Paho MQTT C++_
+&emsp; _Install Paho MQTT C++_
 
 ```bash
 git clone https://github.com/eclipse/paho.mqtt.cpp
@@ -37,13 +36,15 @@ sudo cmake --build build/ --target install
 sudo ldconfig
 ```
 
-- Alternatively, if your package manager provides recent Paho MQTT libraries:
+&emsp; Alternatively, if your package manager provides recent Paho MQTT libraries:
 
 ```bash
 sudo apt install libpaho-mqtt-dev libpaho-mqttpp-dev
 ```
 
-3. Build and install the plugin:
+3. **Build and install the plugin:**
+
+&emsp; Plugin repos should be cloned in a location other than the trunk-recorder source dir.
 
 ```bash
 mkdir build
@@ -51,6 +52,8 @@ cd build
 cmake ..
 sudo make install
 ```
+
+&emsp; **IMPORTANT NOTE:** To avoid SEGFAULTs or other errors, plugins should be rebuilt after every new release of trunk-recorder.
 
 ## Configure
 
@@ -69,13 +72,13 @@ sudo make install
 
 **Trunk-Recorder options:**
 
-| Key                          | Required | Default Value  | Type   | Description                                                                                |
-| ---------------------------- | :------: | -------------- | ------ | ------------------------------------------------------------------------------------------ |
+| Key                          | Required | Default Value               | Type   | Description                                                                                |
+| ---------------------------- | :------: | --------------------------- | ------ | ------------------------------------------------------------------------------------------ |
 | [instance_id](./config.json) |          | <nobr>trunk-recorder</nobr> | string | Append an `instance_id` key to identify the trunk-recorder instance sending MQTT messages. |
 
-## Plugin Usage Example
+**Plugin Usage:**
 
-See the included [config.json](./config.json) as an example of how to load this plugin.
+See the included [config.json](./config.json) for an example how to load this plugin.
 
 ```json
     "plugins": [
@@ -99,6 +102,8 @@ If the plugin cannot be found, or it is being run from a different location, it 
 ```
 
 ## MQTT Messages
+
+The plugin will provide the following messges to the MQTT broker depending on configured topics.
 
 | Topic                   | Sub-Topic                                          | Retained | Description\*                                                      |
 | ----------------------- | -------------------------------------------------- | :------: | ------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# Trunk Recorder MQTT Status (and Units!) Plugin
+# Trunk Recorder MQTT Status (and Units!) Plugin <!-- omit from toc --> 
 
 This is a plugin for Trunk Recorder that publish the current status over MQTT. External programs can use the MQTT messages to display what is going on.
+
+- [Install](#install)
+- [Configure](#configure)
+- [Plugin Usage Example](#plugin-usage-example)
+- [MQTT Messages](#mqtt-messages)
+- [Mosquitto MQTT Broker](#mosquitto-mqtt-broker)
+- [Docker](#docker)
 
 ## Install
 
@@ -8,7 +15,8 @@ This is a plugin for Trunk Recorder that publish the current status over MQTT. E
 
 2. **Install the Paho MQTT C & C++ Libraries**.
 
-- *Install Paho MQTT C*
+- _Install Paho MQTT C_
+
 ```bash
 git clone https://github.com/eclipse/paho.mqtt.c.git
 cd paho.mqtt.c
@@ -18,7 +26,8 @@ sudo cmake --build build/ --target install
 sudo ldconfig
 ```
 
-- *Install Paho MQTT C++*
+- _Install Paho MQTT C++_
+
 ```bash
 git clone https://github.com/eclipse/paho.mqtt.cpp
 cd paho.mqtt.cpp
@@ -34,7 +43,6 @@ sudo ldconfig
 sudo apt install libpaho-mqtt-dev libpaho-mqttpp-dev
 ```
 
-
 3. Build and install the plugin:
 
 ```bash
@@ -45,27 +53,31 @@ sudo make install
 ```
 
 ## Configure
-__Plugin options:__
-| Key        | Required | Default Value | Type   | Description                                                  |
-|------------| :------: | ------------- | ------ | ------------------------------------------------------------ |
-| client_id  |          | tr-status     | string | This is the optional client id to send to MQTT. |
-| broker     |    ✓     |   tcp://localhost:1883            | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
-| topic      |    ✓     |               | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages. |
-| unit_topic |          |               | string | Optional field to enable reporting of unit stats over MQTT. |
-| message_topic |          |               | string | Optional field to enable reporting of trunking messages over MQTT. |
-| username   |          |               | string | If a username is required for the broker, add it here. |
-| password   |          |               | string | If a password is required for the broker, add it here. |
-| qos    |          |        0     | int    | Set the MQTT message [QOS level](https://www.eclipse.org/paho/files/mqttdoc/MQTTClient/html/qos.html) |
 
-__Trunk-Recorder options:__
-| Location | Key        | Required | Default Value | Type   | Description                                                  |
-|------------|------------| :------: | ------------- | ------ | ------------------------------------------------------------ |
-| [top-level](./config.json) | instance_id |          |   trunk-recorder   | string | If multiple `trunk-recorder`s are reporting to a central location, an `instance_id` can be appended to each MQTT message to identify data origin. |
+**Plugin options:**
 
-### Plugin Usage Example
+| Key           | Required | Default Value        | Type   | Description                                                                                                                                                                              |
+| ------------- | :------: | -------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| client_id     |          | tr-status            | string | This is the optional client id to send to MQTT.                                                                                                                                          |
+| broker        |    ✓     | tcp://localhost:1883 | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
+| topic         |    ✓     |                      | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages.                                                                              |
+| unit_topic    |          |                      | string | Optional field to enable reporting of unit stats over MQTT.                                                                                                                              |
+| message_topic |          |                      | string | Optional field to enable reporting of trunking messages over MQTT.                                                                                                                       |
+| username      |          |                      | string | If a username is required for the broker, add it here.                                                                                                                                   |
+| password      |          |                      | string | If a password is required for the broker, add it here.                                                                                                                                   |
+| qos           |          | 0                    | int    | Set the MQTT message [QOS level](https://www.eclipse.org/paho/files/mqttdoc/MQTTClient/html/qos.html)                                                                                    |
+
+**Trunk-Recorder options:**
+
+| Key                          | Required | Default Value  | Type   | Description                                                                                |
+| ---------------------------- | :------: | -------------- | ------ | ------------------------------------------------------------------------------------------ |
+| [instance_id](./config.json) |          | <nobr>trunk-recorder</nobr> | string | Append an `instance_id` key to identify the trunk-recorder instance sending MQTT messages. |
+
+## Plugin Usage Example
+
 See the included [config.json](./config.json) as an example of how to load this plugin.
 
-```yaml
+```json
     "plugins": [
     {
         "name": "MQTT Status",
@@ -79,42 +91,47 @@ See the included [config.json](./config.json) as an example of how to load this 
         "qos": 0
     }]
 ```
+
 If the plugin cannot be found, or it is being run from a different location, it may be necesarry to supply the full path:
-```yaml
+
+```json
         "library": "/usr/local/lib/trunk-recorder/libmqtt_status_plugin.so",
 ```
 
-### MQTT Messages
-| Topic | Sub-Topic | Retained | Description |
-| ----- | --------- | -------- | ----------- |
-| topic | rates | no | Control channel decode rates |
-| topic | config | yes | Trunk-recorder config information  |
-| topic | systems | yes | Configured systems |
-| topic | system | no | System info, sent when configuration is complete|
-| topic | calls_active | no | List of active calls, updated every 1 second|
-| topic | recorders | no | List of system recorders, updated every 3 seconds |
-| topic | recorder | no | Recorder status changes |
-| topic | call_start | no | New calls |
-| topic | call_end | no | Completed calls |
-| topic/trunk_recorder | `client_id` | yes | Plugin status message, sent on startup or when the broker loses connection |
-| unit_topic/shortname | call | no | Channel grants |
-| unit_topic/shortname | end | no | Call end unit information\* |
-| unit_topic/shortname | on | no | Unit registration (radio on) |
-| unit_topic/shortname | off | no | Unit degregistration (radio off) |
-| unit_topic/shortname | ackresp | no | Unit acknowledge response |
-| unit_topic/shortname | join | no | Unit group affiliation |
-| unit_topic/shortname | data | no | Unit data grant |
-| unit_topic/shortname | ans_req | no | Unit answer request |
-| unit_topic/shortname | location | no | Unit location update |
-| message_topic/shortname | messages | no | Trunking messages |
+## MQTT Messages
 
-\*`end` is not a trunking message, but sent after trunk-recorder ends the call.  This can be used to track conventional non-trunked calls.
+| Topic                   | Sub-Topic                                          | Retained | Description\*                                                      |
+| ----------------------- | -------------------------------------------------- | :------: | ------------------------------------------------------------------ |
+| topic                   | [rates](./example_messages.md#rates)               |          | Control channel decode rates                                       |
+| topic                   | [config](./example_messages.md#config)             |    ✓     | Trunk-recorder config information                                  |
+| topic                   | [systems](./example_messages.md#systems)           |    ✓     | List of configured systems                                         |
+| topic                   | [system](./example_messages.md#system)             |          | System configuration/startup                                       |
+| topic                   | [calls_active](./example_messages.md#calls_active) |          | List of active calls, updated every second                         |
+| topic                   | [recorders](./example_messages.md#recorders)       |          | List of all recorders, updated every 3 seconds                     |
+| topic                   | [recorder](./example_messages.md#recorder)         |          | Recorder status changes                                            |
+| topic                   | [call_start](./example_messages.md#call_start)     |          | New call                                                           |
+| topic                   | [call_end](./example_messages.md#call_end)         |          | Completed call                                                     |
+| topic/trunk_recorder    | [`client_id`](./example_messages.md#plugin_status) |    ✓     | Plugin status, sent on startup or when the broker loses connection |
+| unit_topic/shortname    | [call](./example_messages.md#call)                 |          | Channel grants                                                     |
+| unit_topic/shortname    | [end](./example_messages.md#end)                   |          | Call end unit information\*\*                                      |
+| unit_topic/shortname    | [on](./example_messages.md#on)                     |          | Unit registration (radio on)                                       |
+| unit_topic/shortname    | [off](./example_messages.md#off)                   |          | Unit degregistration (radio off)                                   |
+| unit_topic/shortname    | [ackresp](./example_messages.md#ackresp)           |          | Unit acknowledge response                                          |
+| unit_topic/shortname    | [join](./example_messages.md#join)                 |          | Unit group affiliation                                             |
+| unit_topic/shortname    | [data](./example_messages.md#data)                 |          | Unit data grant                                                    |
+| unit_topic/shortname    | [ans_req](./example_messages.md#ans_req)           |          | Unit answer request                                                |
+| unit_topic/shortname    | [location](./example_messages.md#location)         |          | Unit location update                                               |
+| message_topic/shortname | [messages](./example_messages.md#messages)         |          | Trunking messages                                                  |
 
-### Mosquitto MQTT Broker
-The Mosquitto MQTT is an easy way to have a local MQTT broker. It can be installed from a lot of package managers. 
+\* Some messages have been changed for consistency. Please see links for examples and notes.  
+\*\* `end` is not a trunking message, but sent after trunk-recorder ends the call. This can be used to track conventional non-trunked calls.
 
+## Mosquitto MQTT Broker
+
+The [Mosquitto](https://mosquitto.org) MQTT is an easy way to have a local MQTT broker. It can be installed from a lot of package managers.
 
 Starting it on a Mac:
+
 ```bash
 /opt/homebrew/sbin/mosquitto -c /opt/homebrew/etc/mosquitto/mosquitto.conf
 ```
@@ -123,12 +140,12 @@ Starting it on a Mac:
 
 The included Dockerfile will allow buliding a trunk-recorder docker image with this plugin included.
 
-`docker-compose` can be used to automate the build and deployment of this image. In the Docker compose file replace the image line with a build line pointing to the location where this repo has been cloned to.   
+`docker-compose` can be used to automate the build and deployment of this image. In the Docker compose file replace the image line with a build line pointing to the location where this repo has been cloned to.
 
 Docker compose file:
 
 ```yaml
-version: '3'
+version: "3"
 services:
   recorder:
     build: ./trunk-recorder-mqtt-status
@@ -137,7 +154,7 @@ services:
     privileged: true
     volumes:
       - /dev/bus/usb:/dev/bus/usb
-      - /var/run/dbus:/var/run/dbus 
+      - /var/run/dbus:/var/run/dbus
       - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
       - ./:/app
 ```

--- a/example_messages.md
+++ b/example_messages.md
@@ -1,0 +1,852 @@
+# Example MQTT Messages <!-- omit from toc -->
+
+- [Status Messages](#status-messages)
+  - [rates](#rates)
+  - [config](#config)
+  - [systems](#systems)
+  - [system](#system)
+  - [calls\_active](#calls_active)
+  - [recorders](#recorders)
+  - [recorder](#recorder)
+  - [call\_start](#call_start)
+  - [call\_end](#call_end)
+  - [plugin\_status](#plugin_status)
+- [Unit Messages](#unit-messages)
+  - [call](#call)
+  - [end](#end)
+  - [on](#on)
+  - [off](#off)
+  - [ackresp](#ackresp)
+  - [join](#join)
+  - [data](#data)
+  - [ans\_req](#ans_req)
+  - [location](#location)
+- [Trunking Messages](#trunking-messages)
+  - [messages](#messages)
+
+# Status Messages
+
+## rates
+
+Trunk message rate reporting by system
+
+`topic/rates`
+
+```json
+{
+  "rates": [
+    {
+      "sys_num": "2",
+      "sys_name": "p25trunk",
+      "decoderate": "39.67",
+      "decoderate_interval": "3",
+      "control_channel": "774581250"
+    },
+    {
+      "sys_num": "3",
+      "sys_name": "p25trunk2",
+      "decoderate": "35.00",
+      "decoderate_interval": "3",
+      "control_channel": "853750000"
+    }
+  ],
+  "type": "rates",
+  "timestamp": "1686699024",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+rates
+  id -> sys_num
+      + sys_name
+      + decoderate_interval
+      + control_channel
+
+Conventional systems are omitted from rate reporting by the plugin.
+```
+
+## config
+
+Trunk-recorder souce and system config information. The message is retained on the MQTT broker.
+
+`topic/config`
+
+```json
+{
+    "config": {
+        "sources": [
+            {
+                "source_num": "0",
+                "rate": "2400000",
+                "center": "772906250",
+                "min_hz": "771756250",
+                "max_hz": "774056250",
+                "error": "0",
+                "driver": "osmosdr",
+                "device": "rtl=03",
+                "antenna": "",
+                "gain": "32",
+                "analog_recorders": "0",
+                "digital_recorders": "5",
+                "debug_recorders": "0",
+                "sigmf_recorders": "0",
+                "silence_frames": "0"
+            },
+            {
+                ...
+            }
+        ],
+        "systems": [
+            {
+                "sys_num": "0",
+                "sys_name": "p25con",
+                "system_type": "conventionalP25",
+                "talkgroups_file": "",
+                "qpsk": "true",
+                "squelch_db": "-55",
+                "analog_levels": "8",
+                "digital_levels": "1",
+                "audio_archive": "false",
+                "upload_script": "",
+                "record_unkown": "true",
+                "call_log": "false",
+                "channels": ""
+            },
+            {
+                "sys_num": "1",
+                "sys_name": "con",
+                "system_type": "conventional",
+                "talkgroups_file": "",
+                "qpsk": "true",
+                "squelch_db": "-45",
+                "analog_levels": "16",
+                "digital_levels": "1",
+                "audio_archive": "false",
+                "upload_script": "",
+                "record_unkown": "true",
+                "call_log": "false",
+                "channels": ""
+            },
+            {
+                "sys_num": "2",
+                "sys_name": "p25trunk",
+                "system_type": "p25",
+                "talkgroups_file": "p25/trunk.csv",
+                "qpsk": "true",
+                "squelch_db": "-160",
+                "analog_levels": "8",
+                "digital_levels": "1",
+                "audio_archive": "false",
+                "upload_script": "",
+                "record_unkown": "true",
+                "call_log": "false",
+                "control_channel": "774581250",
+                "channels": [
+                    "774581250",
+                    "772431250",
+                    "773456250",
+                    "774031250"
+                ]
+            },
+            {
+                ...
+            }
+        ],
+        "capture_dir": "/dev/shm/trunk-recorder",
+        "upload_server": "https://api.openmhz.com",
+        "call_timeout": "3",
+        "log_file": "false",
+        "instance_id": "east-antenna",
+        "instance_key": ""
+    },
+    "type": "config",
+    "timestamp": "1686400353",
+    "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+config
+  systems
+    audioArchive    -> audio_archive
+    systemType      -> system_type
+    shortName       -> sys_name
+    sysNum          -> sys_num
+    uploadScript    -> upload_script
+    recordUnkown    -> record_unknown
+    callLog         -> call_log
+    talkgroupsFile  -> talkgroups_file
+  captureDir      -> capture_dir
+  uploadServer    -> upload_server
+  callTimeout     -> call_timeout
+  logFile         -> log_file
+  instanceId      -> instance_id
+  instanceKey     -> instance_key
+```
+
+## systems
+
+Configured systems are sent during startup. The message is retained on the MQTT broker.
+
+`topic/systems`
+
+```json
+{
+  "systems": [
+    {
+      "sys_num": "0",
+      "sys_name": "p25con",
+      "type": "conventionalP25",
+      "sysid": "0",
+      "wacn": "0",
+      "nac": "0"
+    },
+    {
+      "sys_num": "1",
+      "sys_name": "con",
+      "type": "conventional",
+      "sysid": "0",
+      "wacn": "0",
+      "nac": "0"
+    },
+    {
+      "sys_num": "2",
+      "sys_name": "p25trunk",
+      "type": "p25",
+      "sysid": "555",
+      "wacn": "BBBBB",
+      "nac": "BCC"
+    }
+  ],
+  "type": "systems",
+  "timestamp": "1686400355",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+systems
+  id   -> sys_num
+  name -> sys_name
+```
+
+## system
+
+Sent after a system is configured during trunk-recorder startup.
+
+`topic/system`
+
+```json
+{
+  "system": {
+    "id": "3",
+    "name": "p25trunk",
+    "type": "p25",
+    "sysid": "555",
+    "wacn": "BBBBB",
+    "nac": "BCC"
+  },
+  "type": "system",
+  "timestamp": "1686146741",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+system
+  id   -> sys_num
+  name -> sys_name
+```
+
+## calls_active
+
+List of active calls, updated every second.
+
+`topic/calls_active`
+
+```json
+{
+    "calls": [
+        {
+            "id": "2_4011_1686699318",
+            "call_num": "51442",
+            "freq": "771356250",
+            "sys_num": "2",
+            "sys_name": "p25trunk",
+            "talkgroup": "4011",
+            "talkgroup_alpha_tag": "Bus 1",
+            "unit": "899003",
+            "unit_alpha_tag": "Trans 9003",
+            "elapsed": "12",
+            "length": "7.48",
+            "call_state": "1",
+            "call_state_type": "RECORDING",
+            "mon_state": "0",
+            "mon_state_type": "UNSPECIFIED",
+            "rec_num": "0",
+            "src_num": "1",
+            "rec_state": "4",
+            "rec_state_type": "IDLE",
+            "phase2": "true",
+            "analog": "false",
+            "conventional": "false",
+            "encrypted": "false",
+            "emergency": "false",
+            "stop_time": "1686699318"
+        },
+        {
+            ...
+        }
+    ],
+    "type": "calls_active",
+    "timestamp": "1686699330",
+    "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+calls
+  callNum      -> call_num
+  sysNum       -> sys_num
+  shortName    -> sys_name
+  talkgrouptag -> talkgroup_alpha_tag
+  srcId        -> unit
+                + unit_alpha_tag
+  state        -> call_state
+                + call_state_type
+  monState     -> mon_state
+                + mon_state_type
+  recNum       -> rec_num
+  srcNum       -> src_num
+  recState     -> rec_state
+                + rec_state_type
+  stopTime     -> stop_time
+```
+
+## recorders
+
+List of all recorders, updated every 3 seconds.
+
+`topic/recorder`
+
+```json
+{
+    "recorders": [
+        {
+            "id": "0_19",
+            "src_num": "0",
+            "rec_num": "19",
+            "type": "P25C",
+            "duration": "706.50",
+            "freq": "457750000",
+            "count": "73",
+            "rec_state": "4",
+            "rec_state_type": "IDLE"
+        },
+        {
+            ...
+        }
+    ],
+    "type": "recorders",
+    "timestamp": "1686699405",
+    "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+recorders
+  srcNum -> src_num
+  recNum -> rec_num
+  state  -> rec_state
+          + rec_state_type
+```
+
+## recorder
+
+Recorder status updates.
+
+`topic/recorder`
+
+```json
+{
+  "recorder": {
+    "id": "4_16",
+    "src_num": "4",
+    "rec_num": "16",
+    "type": "P25",
+    "freq": "852200000",
+    "duration": "21182.10",
+    "count": "3563",
+    "rec_state": "4",
+    "rec_state_type": "IDLE"
+  },
+  "type": "recorder",
+  "timestamp": "1686700173",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+recorder
+  srcNum -> src_num
+  recNum -> rec_num
+  state  -> rec_state
+          + rec_state_type
+```
+
+## call_start
+
+Sent when a new trunked call starts, or when a conventional recorder is reset after a call.
+
+`topic/call_start`
+
+```json
+{
+  "call": {
+    "id": "2_3029_1686700194",
+    "call_num": "51684",
+    "freq": "770331250",
+    "sys_num": "2",
+    "sys_name": "p25trunk",
+    "talkgroup": "3029",
+    "talkgroup_alpha_tag": "Metro Police",
+    "unit": "849183",
+    "unit_alpha_tag": "Metro Dispatch",
+    "elapsed": "0",
+    "length": "0.00",
+    "call_state": "0",
+    "call_state_type": "MONITORING",
+    "mon_state": "6",
+    "mon_state_type": "DUPLICATE",
+    "rec_num": "",
+    "src_num": "",
+    "rec_state": "",
+    "rec_state_type": "",
+    "phase2": "false",
+    "analog": "",
+    "conventional": "false",
+    "encrypted": "false",
+    "emergency": "false",
+    "stop_time": "1686700194"
+  },
+  "type": "call_start",
+  "timestamp": "1686700194",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+call
+  callNum      -> call_num
+  sysNum       -> sys_num
+  shortName    -> sys_name
+  talkgrouptag -> talkgroup_alpha_tag
+  srcId        -> unit
+                + unit_alpha_tag
+  state        -> call_state
+                + call_state_type
+  monState     -> mon_state
+                + mon_state_type
+  recNum       -> rec_num
+  srcNum       -> src_num
+  recState     -> rec_state
+                + rec_state_type
+  stopTime     -> stop_time
+```
+
+## call_end
+
+Sent after trunk-recorder completes recording a call.
+
+`topic/call_end`
+
+```json
+{
+  "call": {
+    "call_num": "51697",
+    "sys_name": "p25trunk",
+    "start_time": "1686700238",
+    "stop_time": "1686700263",
+    "length": "17.60",
+    "process_call_time": "1686700268",
+    "retry_attempt": "0",
+    "error_count": "0",
+    "spike_count": "0",
+    "freq": "771606250",
+    "encrypted": "false",
+    "emergency": "false",
+    "tdma_slot": "1",
+    "phase2_tdma": "true",
+    "talkgroup": "4012",
+    "talkgroup_tag": "Transportation",
+    "talkgroup_alpha_tag": "Bus 2",
+    "talkgroup_description": "Bus Dispatch 2",
+    "talkgroup_group": "Transit",
+    "talkgroup_patches": "",
+    "audio_type": "digital tdma"
+  },
+  "type": "call_end",
+  "timestamp": "1686700268",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+call
+  short_name -> sys_name
+  callNum    -> call_num
+```
+
+## plugin_status
+
+Plugin status message, sent on startup or when the broker loses connection. The message is retained on the MQTT broker.
+
+`topic/trunk_recorder/tr-status`
+
+```json
+{
+  "status": "connected",
+  "instance_id": "east-antenna",
+  "client_id": "tr-status"
+}
+```
+
+# Unit Messages
+
+## call
+
+Channel grants. Sent when a call starts.
+
+`unit_topic/shortname/call`
+
+```json
+{
+  "call": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "call_num": "51869",
+    "start_time": "1686700982",
+    "freq": "770581250",
+    "unit": "804329",
+    "unit_alpha_tag": "State Port. 329",
+    "talkgroup": "301",
+    "talkgroup_alpha_tag": "State Disp 1",
+    "talkgroup_patches": "",
+    "encrypted": "false"
+  },
+  "type": "call",
+  "timestamp": "1686700985",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+call
+              + sys_num
+  system     -> sys_name
+  callNum    -> call_num
+  unit_alpha -> unit_alpha_tag
+```
+
+## end
+
+Call end information by transmission. Reports information for conventional units.
+
+`unit_topic/shortname/end`
+
+```json
+{
+  "end": {
+    "call_num": "53726",
+    "sys_name": "p25trunk",
+    "unit": "46999",
+    "unit_alpha_tag": "Bus 999",
+    "start_time": "1686711476",
+    "stop_time": "1686711483",
+    "sample_count": "50560",
+    "spike_count": "0",
+    "error_count": "0",
+    "freq": "769656250",
+    "length": "6.32",
+    "transmission_filename": "/dev/shm/p25trunk/4012-1686711476_769656250.wav",
+    "call_filename": "/dev/shm/trunk-recorder/p25trunk/2023/6/13/4012-1686711439_769656250.0-call_53726.wav",
+    "position": "33.40",
+    "talkgroup": "4012",
+    "talkgroup_alpha_tag": "Bus 2",
+    "talkgroup_description": "Bus Dispatch 2",
+    "talkgroup_group": "Transit",
+    "talkgroup_patches": "",
+    "encrypted": "false",
+    "emergency": "false",
+    "signal_system": ""
+  },
+  "type": "end",
+  "timestamp": "1686711488",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+call
+  callNum    -> call_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## on
+
+Unit registration (radio turned on)
+
+`unit_topic/shortname/on`
+
+```json
+{
+  "on": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "806308",
+    "unit_alpha_tag": "State Port. 308"
+  },
+  "type": "on",
+  "timestamp": "1686711527",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+on
+              + sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## off
+
+Unit de-registration (radio turned off)
+
+`unit_topic/shortname/off`
+
+```json
+{
+  "off": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "804422",
+    "unit_alpha_tag": "State Port. 422"
+  },
+  "type": "off",
+  "timestamp": "1686711529",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+off
+              + sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## ackresp
+
+Unit acknowledge response.
+
+`unit_topic/shortname/ackresp`
+
+```json
+{
+  "ackresp": {
+    "sys_num": "2",
+    "sys_name": "p25trunk",
+    "unit": "52001",
+    "unit_alpha_tag": "FD Mobile 001"
+  },
+  "type": "ackresp",
+  "timestamp": "1686711630",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+ackresp
+              + sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## join
+
+Unit group affiliation
+
+`unit_topic/shortname/join`
+
+```json
+{
+  "join": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "806109",
+    "unit_alpha_tag": "State Port. 109",
+    "talkgroup": "401",
+    "talkgroup_alpha_tag": "State Disp 1",
+    "talkgroup_patches": ""
+  },
+  "type": "join",
+  "timestamp": "1686711676",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+join
+  sysNum     -> sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## data
+
+Unit data grant
+
+`unit_topic/shortname/data`
+
+```json
+{
+  "data": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "849006",
+    "unit_alpha_tag": ""
+  },
+  "type": "data",
+  "timestamp": "1686712418",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+data
+              + sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## ans_req
+
+Unit answer request
+
+`unit_topic/shortname/ans_req`
+
+```json
+{
+  "ans_req": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "2048",
+    "unit_alpha_tag": "",
+    "talkgroup": "12582912"
+  },
+  "type": "ans_req",
+  "timestamp": "1686712433",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+ans_req
+              + sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+## location
+
+Unit location update
+
+`unit_topic/shortname/location`
+
+```json
+{
+  "location": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "unit": "54126",
+    "unit_alpha": "FD Port. 126",
+    "talkgroup": "23507",
+    "talkgroup_alpha_tag": "FD",
+    "talkgroup_patches": ""
+  },
+  "type": "location",
+  "timestamp": "1686712458",
+  "instance_id": "east-antenna"
+}
+```
+
+Changes:
+
+```
+location
+  sysNum     -> sys_num
+  system     -> sys_name
+  unit_alpha -> unit_alpha_tag
+```
+
+# Trunking Messages
+
+## messages
+
+Overview of trunking messages that have been decoded.
+
+`message_topic/shortname/messages`
+
+```json
+{
+  "message": {
+    "sys_num": "3",
+    "sys_name": "p25trunk",
+    "trunk_msg": "3",
+    "trunk_msg_type": "CONTROL_CHANNEL",
+    "opcode": "39",
+    "opcode_type": "SCCB",
+    "opcode_desc": "Secondary Control Channel Broadcast"
+  },
+  "type": "message",
+  "timestamp": "1686712507",
+  "instance_id": "east-antenna"
+}
+```

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -41,54 +41,72 @@ class Mqtt_Status : public Plugin_Api, public virtual mqtt::callback, public vir
 
   time_t call_resend_time = time(NULL);
 
-  std::map<std::string, int> system_map;
-
-  std::map<short, std::string> opcode_type = {
-      {0x00, "GRP_V_CH_GRANT"},
-      {0x02, "GRP_V_CH_GRANT_UPDT"},
-      {0x03, "GRP_V_CH_GRANT_UPDT_EXP"},
-      {0x04, "UU_V_CH_GRANT"},
-      {0x05, "UU_ANS_REQ"},
-      {0x06, "UU_V_CH_GRANT_UPDT"},
-      {0x08, "Telephone Interconnect Voice Channel Grant"},
-      {0x09, "Telephone Interconnect Voice Channel Grant Update"},
-      {0x0a, "Telephone Interconnect Answer Request"},
-      {0x14, "DATA_GRANT"},
-      {0x15, "SNDCP Data Page Request"},
-      {0x16, "SNDCP Data Channel Announcement -Explicit"},
-      {0x18, "Status Update"},
-      {0x1a, "Status Query"},
-      {0x1c, "Message Update"},
-      {0x1d, "Radio Unit Monitor Command"},
-      {0x1f, "Call Alert"},
-      {0x20, "Acknowledge Response"},
-      {0x21, "Extended Function Command"},
-      {0x24, "Extended Function Command"},
-      {0x27, "Deny Response"},
-      {0x28, "Unit Group Affiliation"},
-      {0x29, "Secondary Control Channel Broadcast - Explicit"},
-      {0x2a, "Group Affiliation Query"},
-      {0x2b, "Location Registration Response"},
-      {0x2c, "Unit Registration Response"},
-      {0x2d, "AUTHENTICATION COMMAND"},
-      {0x2e, "DE-REGISTRATION ACKNOWLEDGE"},
-      {0x2f, "Unit DeRegistration Ack"},
-      {0x30, "TDMA SYNCHRONIZATION BROADCAST / PATCH"},
-      {0x31, "AUTHENTICATION DEMAND"},
-      {0x32, "AUTHENTICATION RESPONSE"},
-      {0x33, "iden up tdma id"},
-      {0x34, "iden vhf/uhf id"},
-      {0x35, "Time and Date Announcement"},
-      {0x36, "ROAMING ADDRESS COMMAND"},
-      {0x37, "ROAMING ADDRESS UPDATE"},
-      {0x38, "SYSTEM SERVICE BROADCAST"},
-      {0x39, "secondary cc"},
-      {0x3a, "rfss status"},
-      {0x3b, "network status"},
-      {0x3c, "adjacent status"},
-      {0x3d, "iden_up"},
-      {0x3e, "P_PARM_BCST"},
-      {0xff, "** Unidentified"}};
+  std::map<short, std::vector<std::string>> opcode_type = {
+      {0x00, {"GRP_V_CH_GRANT", "Group Voice Channel Grant"}},
+      {0x01, {"RSVD_01", "Reserved 0x01"}},
+      {0x02, {"GRP_V_CH_GRANT_UPDT", "Group Voice Channel Grant Update"}},
+      {0x03, {"GRP_V_CH_GRANT_UPDT_EXP", "Group Voice Channel Update - Explicit"}},
+      {0x04, {"UU_V_CH_GRANT", "Unit To Unit Voice Channel Grant"}},
+      {0x05, {"UU_ANS_REQ", "Unit To Unit Answer Request"}},
+      {0x06, {"UU_V_CH_GRANT_UPDT", "Unit to Unit Voice Channel Grant Update"}},
+      {0x07, {"RSVD_07", "Reserved 0x07"}},
+      {0x08, {"TELE_INT_CH_GRANT", "Telephone Interconnect Voice Channel Grant"}},
+      {0x09, {"TELE_INT_CH_GRANT_UPDT", "Telephone Interconnect Voice Channel Grant Update"}},
+      {0x0a, {"TELE_INT_ANS_REQ", "Telephone Interconnect Answer Request"}},
+      {0x0b, {"RSVD_0B", "Reserved 0x0b"}},
+      {0x0c, {"RSVD_0C", "Reserved 0x0c"}},
+      {0x0d, {"RSVD_0D", "Reserved 0x0d"}},
+      {0x0e, {"RSVD_0E", "Reserved 0x0e"}},
+      {0x0f, {"RSVD_0F", "Reserved 0x0f"}},
+      {0x10, {"OBS_10", "Obsolete 0x10"}},
+      {0x11, {"OBS_11", "Obsolete 0x11"}},
+      {0x12, {"OBS_12", "Obsolete 0x12"}},
+      {0x13, {"OBS_13", "Obsolete 0x13"}},
+      {0x14, {"SN-DATA_CHN_GNT", "SNDCP Data Channel Grant"}},
+      {0x15, {"SN-DATA_PAGE_REQ", "SNDCP Data Page Request"}},
+      {0x16, {"SN-DATA_CHN_ANN_EXP", "SNDCP Data Channel Announcement - Explicit"}},
+      {0x17, {"RSVD_17", "Reserved 0x17"}},
+      {0x18, {"STS_UPDT", "Status Update"}},
+      {0x19, {"RSVD_19", "Reserved 0x19"}},
+      {0x1a, {"STS_Q", "Status Query"}},
+      {0x1b, {"RSVD_1B", "Reserved 0x1b"}},
+      {0x1c, {"MSG_UPDT", "Message Update"}},
+      {0x1d, {"RAD_MON_CMD", "Radio Unit Monitor Command"}},
+      {0x1e, {"RSVD_1E", "Reserved 0x1e"}},
+      {0x1f, {"CALL_ALRT", "Call Alert"}},
+      {0x20, {"ACK_RSP_FNE", "Acknowledge Response - FNE"}},
+      {0x21, {"QUE_RSP", "Queued Response"}},
+      {0x22, {"RSVD_22", "Reserved 0x22"}},
+      {0x23, {"RSVD_23", "Reserved 0x23"}},
+      {0x24, {"EXT_FNCT_CMD", "Extended Function Command"}},
+      {0x25, {"RSVD_25", "Reserved 0x25"}},
+      {0x26, {"RSVD_26", "Reserved 0x26"}},
+      {0x27, {"DENY_RSP", "Deny Response"}},
+      {0x28, {"GRP_AFF_RSP", "Group Affiliation Response"}},
+      {0x29, {"SCCB_EXP", "Secondary Control Channel Broadcast - Explicit"}},
+      {0x2a, {"GRP_AFF_Q", "Group Affiliation Query"}},
+      {0x2b, {"LOC_REG_RSP", "Location Registration Response"}},
+      {0x2c, {"U_REG_RSP", "Unit Registration Response"}},
+      {0x2d, {"U_REG_CMD", "Unit Registration Command"}},
+      {0x2e, {"AUTH_CMD", "Authentication Command"}},
+      {0x2f, {"U_DE_REG_ACK", "De-Registration Acknowledge"}},
+      {0x30, {"SYNC_BCST", "Sync Broadcast / Patch"}},
+      {0x31, {"AUTH_DMD", "Authentication Demand"}},
+      {0x32, {"AUTH_FNE_RESP", "Authentication FNE Response"}},
+      {0x33, {"IDEN_UP_TDMA", "Identifier Update for TDMA"}},
+      {0x34, {"IDEN_UP_VU", "Identifier Update for VHF/UHF Bands"}},
+      {0x35, {"TIME_DATE_ANN", "Time and Date Announcement"}},
+      {0x36, {"ROAM_ADDR_CMD", "Roaming Address Command"}},
+      {0x37, {"ROAM_ADDR_UPDT", "Roaming Address Update"}},
+      {0x38, {"SYS_SRV_BCST", "System Service Broadcast"}},
+      {0x39, {"SCCB", "Secondary Control Channel Broadcast"}},
+      {0x3a, {"RFSS_STS_BCST", "RFSS Status Broadcast"}},
+      {0x3b, {"NET_STS_BCST", "Network Status Broadcast"}},
+      {0x3c, {"ADJ_STS_BCST", "Adjacent Status Broadcast"}},
+      {0x3d, {"IDEN_UP", "Identifier Update"}},
+      {0x3e, {"P_PARM_BCST", "Protection Parameter Broadcast"}},
+      {0x3f, {"P_PARM_UPDT", "Protection Parameter Update"}},
+      {0xff, {"UNK", "Unidentified"}}};
 
   std::map<short, std::string> message_type = {
       {0, "GRANT"},
@@ -156,9 +174,10 @@ public:
         message_node.put("trunk_msg", message.message_type);
         message_node.put("trunk_msg_type", message_type[message.message_type]);
         message_node.put("opcode", int_to_hex(message.opcode, 2));
-        message_node.put("opcode_type", opcode_type[message.opcode]);
+        message_node.put("opcode_type", opcode_type[message.opcode][0]);
+        message_node.put("opcode_desc", opcode_type[message.opcode][1]);
 
-        send_object(message_node, "message", system->get_short_name().c_str(), this->message_topic, false);
+        return send_object(message_node, "message", system->get_short_name().c_str(), this->message_topic, false);
       }
     }
     return 0;
@@ -655,7 +674,7 @@ public:
 
       return send_object(unit_node, "on", "on", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_deregistration(System *sys, long source_id) override
@@ -677,7 +696,7 @@ public:
 
       return send_object(unit_node, "off", "off", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_acknowledge_response(System *sys, long source_id) override
@@ -699,7 +718,7 @@ public:
 
       return send_object(unit_node, "ackresp", "ackresp", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_group_affiliation(System *sys, long source_id, long talkgroup_num) override
@@ -729,7 +748,7 @@ public:
 
       return send_object(unit_node, "join", "join", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_data_grant(System *sys, long source_id) override
@@ -751,7 +770,7 @@ public:
 
       return send_object(unit_node, "data", "data", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_answer_request(System *sys, long source_id, long talkgroup) override
@@ -779,7 +798,7 @@ public:
 
       return send_object(unit_node, "ans_req", "ans_req", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   int unit_location(System *sys, long source_id, long talkgroup_num) override
@@ -808,7 +827,7 @@ public:
       unit_node.put("talkgroup_patches", patch_string);
       return send_object(unit_node, "location", "location", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
-    return 1;
+    return 0;
   }
 
   // ********************************
@@ -1101,7 +1120,7 @@ public:
       BOOST_LOG_TRIVIAL(error) << "MQTT Status Plugin - " << exc.what() << endl;
     }
 
-    return 1;
+    return 0;
   }
 
   // Paho mqtt::iaction_listeners.  Required, but not used.

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -881,16 +881,6 @@ public:
     this->systems = systems;
     this->config = config;
 
-    // Build a system_map for get_system_by_shortname() if needed later.
-    int sys_number = 0;
-    for (std::vector<System *>::iterator it = systems.begin(); it != systems.end(); ++it)
-    {
-      System *sys = (System *)*it;
-      std::string short_name = sys->get_short_name();
-      this->system_map[short_name] = sys_number;
-      sys_number += 1;
-    }
-
     return 0;
   }
 
@@ -966,18 +956,6 @@ public:
     }
     
     return 0;
-  }
-
-  System *get_system_by_shortname(std::string short_name)
-  {
-    // Workaround to find a system by its shortname to aid in metadata lookups.
-
-    // Example:
-    //   System *sys = get_system_by_shortname(call_info.short_name);
-    //   BOOST_LOG_TRIVIAL(error) << sys->get_short_name();
-
-    int sys_num = system_map[short_name];
-    return this->systems[sys_num];
   }
 
   std::string int_to_hex(int num, int places)

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -386,7 +386,8 @@ public:
 
     // MQTT: topic/calls_active
     //   Send the list of all active calls; use a pointer to allow
-    //   updates between the normal API calls
+    //   updates between the normal API calls.
+    //   Not all calls have recorder info
 
     // Reset a pointer to the active call list if needed later
     this->tr_calls = calls;
@@ -417,22 +418,16 @@ public:
         call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]);
         call_node.put("mon_state", stat_node.get<std::string>("monState"));
         call_node.put("mon_state_type", mon_state[stat_node.get<int>("monState")]);
-
+        call_node.put("rec_num", stat_node.get<std::string>("recNum", ""));
+        call_node.put("src_num", stat_node.get<std::string>("srcNum", ""));
+        call_node.put("rec_state", stat_node.get<std::string>("recState", ""));
+        call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState", -1)]);
         call_node.put("phase2", stat_node.get<std::string>("phase2"));
+        call_node.put("analog", stat_node.get<std::string>("analog", ""));
         call_node.put("conventional", stat_node.get<std::string>("conventional"));
         call_node.put("encrypted", stat_node.get<std::string>("encrypted"));
         call_node.put("emergency", stat_node.get<std::string>("emergency"));
         call_node.put("stop_time", stat_node.get<std::string>("stopTime"));
-
-        // Not all calls have recorder info
-        if (stat_node.count("recNum"))
-        {
-          call_node.put("rec_num", stat_node.get<std::string>("recNum"));
-          call_node.put("src_num", stat_node.get<std::string>("srcNum"));
-          call_node.put("rec_state", stat_node.get<std::string>("recState"));
-          call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]);
-          call_node.put("analog", stat_node.get<std::string>("analog"));
-        }
 
         calls_node.push_back(std::make_pair("", call_node));
       }
@@ -503,6 +498,7 @@ public:
     //   Send information about a new call.
     // MQTT: unit_topic/shortname/call
     //   Send information on the unit initiating a new call.
+    //   Not all calls have recorder info.
 
     long talkgroup_num = call->get_talkgroup();
     long source_id = call->get_current_source_id();
@@ -545,22 +541,16 @@ public:
     call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]);
     call_node.put("mon_state", stat_node.get<std::string>("monState"));
     call_node.put("mon_state_type", mon_state[stat_node.get<int>("monState")]);
-
+    call_node.put("rec_num", stat_node.get<std::string>("recNum", ""));
+    call_node.put("src_num", stat_node.get<std::string>("srcNum", ""));
+    call_node.put("rec_state", stat_node.get<std::string>("recState", ""));
+    call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState", -1)]);
     call_node.put("phase2", stat_node.get<std::string>("phase2"));
+    call_node.put("analog", stat_node.get<std::string>("analog", ""));
     call_node.put("conventional", stat_node.get<std::string>("conventional"));
     call_node.put("encrypted", stat_node.get<std::string>("encrypted"));
     call_node.put("emergency", stat_node.get<std::string>("emergency"));
     call_node.put("stop_time", stat_node.get<std::string>("stopTime"));
-
-    // Not all calls have recorder info
-    if (stat_node.count("recNum"))
-    {
-      call_node.put("rec_num", stat_node.get<std::string>("recNum"));
-      call_node.put("src_num", stat_node.get<std::string>("srcNum"));
-      call_node.put("rec_state", stat_node.get<std::string>("recState"));
-      call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]);
-      call_node.put("analog", stat_node.get<std::string>("analog"));
-    }
 
     return send_object(call_node, "call", "call_start", this->topic, false);
   }
@@ -639,19 +629,6 @@ public:
     call_node.put("talkgroup_patches", patch_string);
     call_node.put("audio_type", call_info.audio_type);
 
-    // call_node.put("status",call_info.status);
-    // call_node.put("transmission_list",call_info.transmission_list);
-    // call_node.put("upload_script",call_info.upload_script = sys->get_upload_script();
-    // call_node.put("audio_archive",call_info.audio_archive = sys->get_audio_archive();
-    // call_node.put("transmission_archive",call_info.transmission_archive = sys->get_transmission_archive();
-    // call_node.put("call_log",call_info.call_log = sys->get_call_log();
-    // call_node.put("compress_wav",call_info.compress_wav);
-    // call_node.put("talkgroup_display",call_info.talkgroup_display = call->get_talkgroup_display();
-    // call_info.min_transmissions_removed = 0;
-    // call_node.put("transmission_source_list",call_info.transmission_source_list);
-    // call_node.put("transmission_error_list",call_info.transmission_error_list);
-
-    // Some stats are rounded to prevent long/repeating floats
     return send_object(call_node, "call", "call_end", this->topic, false);
   }
 

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -44,113 +44,110 @@ class Mqtt_Status : public Plugin_Api, public virtual mqtt::callback, public vir
   std::map<std::string, int> system_map;
 
   std::map<short, std::string> opcode_type = {
-    {0x00, "GRP_V_CH_GRANT"},
-    {0x02, "GRP_V_CH_GRANT_UPDT"},
-    {0x03, "GRP_V_CH_GRANT_UPDT_EXP"},
-    {0x04, "UU_V_CH_GRANT"},
-    {0x05, "UU_ANS_REQ"},
-    {0x06, "UU_V_CH_GRANT_UPDT"},
-    {0x08, "Telephone Interconnect Voice Channel Grant"},
-    {0x09, "Telephone Interconnect Voice Channel Grant Update"},
-    {0x0a, "Telephone Interconnect Answer Request"},
-    {0x14, "DATA_GRANT"},
-    {0x15, "SNDCP Data Page Request"},
-    {0x16, "SNDCP Data Channel Announcement -Explicit"},
-    {0x18, "Status Update"},
-    {0x1a, "Status Query"},
-    {0x1c, "Message Update"},
-    {0x1d, "Radio Unit Monitor Command"},
-    {0x1f, "Call Alert"},
-    {0x20, "Acknowledge Response"},
-    {0x21, "Extended Function Command"},
-    {0x24, "Extended Function Command"},
-    {0x27, "Deny Response"},
-    {0x28, "Unit Group Affiliation"},
-    {0x29, "Secondary Control Channel Broadcast - Explicit"},
-    {0x2a, "Group Affiliation Query"},
-    {0x2b, "Location Registration Response"},
-    {0x2c, "Unit Registration Response"},
-    {0x2d, "AUTHENTICATION COMMAND"},
-    {0x2e, "DE-REGISTRATION ACKNOWLEDGE"},
-    {0x2f, "Unit DeRegistration Ack"},
-    {0x30, "TDMA SYNCHRONIZATION BROADCAST / PATCH"},
-    {0x31, "AUTHENTICATION DEMAND"},
-    {0x32, "AUTHENTICATION RESPONSE"},
-    {0x33, "iden up tdma id"},
-    {0x34, "iden vhf/uhf id"},
-    {0x35, "Time and Date Announcement"},
-    {0x36, "ROAMING ADDRESS COMMAND"},
-    {0x37, "ROAMING ADDRESS UPDATE"},
-    {0x38, "SYSTEM SERVICE BROADCAST"},
-    {0x39, "secondary cc"},
-    {0x3a, "rfss status"},
-    {0x3b, "network status"},
-    {0x3c, "adjacent status"},
-    {0x3d, "iden_up"},
-    {0x3e, "P_PARM_BCST"},
-    {0xff, "** Unidentified"}
-  };
+      {0x00, "GRP_V_CH_GRANT"},
+      {0x02, "GRP_V_CH_GRANT_UPDT"},
+      {0x03, "GRP_V_CH_GRANT_UPDT_EXP"},
+      {0x04, "UU_V_CH_GRANT"},
+      {0x05, "UU_ANS_REQ"},
+      {0x06, "UU_V_CH_GRANT_UPDT"},
+      {0x08, "Telephone Interconnect Voice Channel Grant"},
+      {0x09, "Telephone Interconnect Voice Channel Grant Update"},
+      {0x0a, "Telephone Interconnect Answer Request"},
+      {0x14, "DATA_GRANT"},
+      {0x15, "SNDCP Data Page Request"},
+      {0x16, "SNDCP Data Channel Announcement -Explicit"},
+      {0x18, "Status Update"},
+      {0x1a, "Status Query"},
+      {0x1c, "Message Update"},
+      {0x1d, "Radio Unit Monitor Command"},
+      {0x1f, "Call Alert"},
+      {0x20, "Acknowledge Response"},
+      {0x21, "Extended Function Command"},
+      {0x24, "Extended Function Command"},
+      {0x27, "Deny Response"},
+      {0x28, "Unit Group Affiliation"},
+      {0x29, "Secondary Control Channel Broadcast - Explicit"},
+      {0x2a, "Group Affiliation Query"},
+      {0x2b, "Location Registration Response"},
+      {0x2c, "Unit Registration Response"},
+      {0x2d, "AUTHENTICATION COMMAND"},
+      {0x2e, "DE-REGISTRATION ACKNOWLEDGE"},
+      {0x2f, "Unit DeRegistration Ack"},
+      {0x30, "TDMA SYNCHRONIZATION BROADCAST / PATCH"},
+      {0x31, "AUTHENTICATION DEMAND"},
+      {0x32, "AUTHENTICATION RESPONSE"},
+      {0x33, "iden up tdma id"},
+      {0x34, "iden vhf/uhf id"},
+      {0x35, "Time and Date Announcement"},
+      {0x36, "ROAMING ADDRESS COMMAND"},
+      {0x37, "ROAMING ADDRESS UPDATE"},
+      {0x38, "SYSTEM SERVICE BROADCAST"},
+      {0x39, "secondary cc"},
+      {0x3a, "rfss status"},
+      {0x3b, "network status"},
+      {0x3c, "adjacent status"},
+      {0x3d, "iden_up"},
+      {0x3e, "P_PARM_BCST"},
+      {0xff, "** Unidentified"}};
 
   std::map<short, std::string> message_type = {
-    {0, "GRANT"},
-    {1, "STATUS"},
-    {2, "UPDATE"},
-    {3, "CONTROL_CHANNEL"},
-    {4, "REGISTRATION"},
-    {5, "DEREGISTRATION"},
-    {6, "AFFILIATION"},
-    {7, "SYSID"},
-    {8, "ACKNOWLEDGE"},
-    {9, "LOCATION"},
-    {10, "PATCH_ADD"},
-    {11, "PATCH_DELETE"},
-    {12, "DATA_GRANT"},
-    {13, "UU_ANS_REQ"},
-    {14, "UU_V_GRANT"},
-    {15, "UU_V_UPDATE"},
-    {99, "UNKNOWN"}
-  };
+      {0, "GRANT"},
+      {1, "STATUS"},
+      {2, "UPDATE"},
+      {3, "CONTROL_CHANNEL"},
+      {4, "REGISTRATION"},
+      {5, "DEREGISTRATION"},
+      {6, "AFFILIATION"},
+      {7, "SYSID"},
+      {8, "ACKNOWLEDGE"},
+      {9, "LOCATION"},
+      {10, "PATCH_ADD"},
+      {11, "PATCH_DELETE"},
+      {12, "DATA_GRANT"},
+      {13, "UU_ANS_REQ"},
+      {14, "UU_V_GRANT"},
+      {15, "UU_V_UPDATE"},
+      {99, "UNKNOWN"}};
 
   std::map<short, std::string> tr_state = {
-    {0, "MONITORING"},
-    {1, "RECORDING"},
-    {2, "INACTIVE"},
-    {3, "ACTIVE"},
-    {4, "IDLE"},
-    {6, "STOPPED"},
-    {7, "AVAILABLE"},
-    {8, "IGNORE"}
-  };
+      {0, "MONITORING"},
+      {1, "RECORDING"},
+      {2, "INACTIVE"},
+      {3, "ACTIVE"},
+      {4, "IDLE"},
+      {6, "STOPPED"},
+      {7, "AVAILABLE"},
+      {8, "IGNORE"}};
 
   std::map<short, std::string> mon_state = {
-    {0, "UNSPECIFIED"}, 
-    {1, "UNKNOWN_TG"},
-    {2, "IGNORED_TG"},
-    {3, "NO_SOURCE"},
-    {4, "NO_RECORDER"},
-    {5, "ENCRYPTED"},
-    {6, "DUPLICATE"},
-    {7, "SUPERSEDED"}
-  };
-
+      {0, "UNSPECIFIED"},
+      {1, "UNKNOWN_TG"},
+      {2, "IGNORED_TG"},
+      {3, "NO_SOURCE"},
+      {4, "NO_RECORDER"},
+      {5, "ENCRYPTED"},
+      {6, "DUPLICATE"},
+      {7, "SUPERSEDED"}};
 
 public:
-  Mqtt_Status() {};
+  Mqtt_Status(){};
 
   // ********************************
   // trunk-recorder MQTT messages
   // ********************************
 
-  int trunk_message(std::vector<TrunkMessage> messages, System *system) override 
+  int trunk_message(std::vector<TrunkMessage> messages, System *system) override
   {
     // TRUNK-RECORDER PLUGIN API
     //   Sent on each trunking message
 
     // MQTT: message_topic/short_name
     //   Lay the groundwork for trunk_message!
-    
-    if ((this->message_enabled)) {  
-      for (std::vector<TrunkMessage>::iterator it = messages.begin(); it != messages.end(); it++) {
+
+    if ((this->message_enabled))
+    {
+      for (std::vector<TrunkMessage>::iterator it = messages.begin(); it != messages.end(); it++)
+      {
         TrunkMessage message = *it;
         boost::property_tree::ptree message_node;
 
@@ -158,13 +155,13 @@ public:
         message_node.put("sys_name", system->get_short_name());
         message_node.put("trunk_msg", message.message_type);
         message_node.put("trunk_msg_type", message_type[message.message_type]);
-        message_node.put("opcode", int_to_hex(message.opcode,2));
+        message_node.put("opcode", int_to_hex(message.opcode, 2));
         message_node.put("opcode_type", opcode_type[message.opcode]);
 
         send_object(message_node, "message", system->get_short_name().c_str(), this->message_topic, false);
       }
     }
-  return 0;
+    return 0;
   }
 
   int system_rates(std::vector<System *> systems, float timeDiff) override
@@ -182,9 +179,10 @@ public:
       System *system = *it;
       std::string sys_type = system->get_system_type();
 
-      // Filter out conventional systems.  They do not have a call rate and 
+      // Filter out conventional systems.  They do not have a call rate and
       // get_current_control_channel() will cause a sefgault on non-trunked systems.
-      if (sys_type.find("conventional") == std::string::npos) {
+      if (sys_type.find("conventional") == std::string::npos)
+      {
         boost::property_tree::ptree stat_node = system->get_stats_current(timeDiff);
         boost::property_tree::ptree system_node;
 
@@ -200,14 +198,11 @@ public:
     return send_object(systems_node, "rates", "rates", this->topic, false);
   }
 
-  void send_config(std::vector<Source *> sources, std::vector<System *> systems)
+  int send_config(std::vector<Source *> sources, std::vector<System *> systems)
   {
     // MQTT: topic/config
-    //   Send elements of the trunk recorder config.json.  
-    //   retained = true ; Message will be kept at the MQTT broker to avoid the need to resend.
-
-    if (m_open == false)
-      return;
+    //   Send elements of the trunk recorder config.json.
+    //   retained = true; Message will be kept at the MQTT broker to avoid the need to resend.
 
     boost::property_tree::ptree root;
     boost::property_tree::ptree systems_node;
@@ -308,7 +303,7 @@ public:
       root.put("broadcast_signals", this->config->broadcast_signals);
     }
 
-    send_object(root, "config", "config", this->topic, true);
+    return send_object(root, "config", "config", this->topic, true);
   }
 
   int setup_systems(std::vector<System *> systems) override
@@ -316,10 +311,10 @@ public:
     // TRUNK-RECORDER PLUGIN API
     //   Called during startup when the systems have been created.
     //   May not have NAC or other details until all systems finish setting up.
-  
+
     // MQTT: topic/systems
     //   Send the configuration information for all systems
-    //   retained = true ; Message will be kept at the MQTT broker to avoid the need to resend.
+    //   retained = true; Message will be kept at the MQTT broker to avoid the need to resend.
 
     boost::property_tree::ptree systems_node;
 
@@ -332,9 +327,9 @@ public:
       system_node.put("sys_num", stat_node.get<std::string>("id"));
       system_node.put("sys_name", stat_node.get<std::string>("name"));
       system_node.put("type", stat_node.get<std::string>("type"));
-      system_node.put("sysid", int_to_hex(stat_node.get<int>("sysid"),0));
-      system_node.put("wacn", int_to_hex(stat_node.get<int>("wacn"),0));
-      system_node.put("nac", int_to_hex(stat_node.get<int>("nac"),0));
+      system_node.put("sysid", int_to_hex(stat_node.get<int>("sysid"), 0));
+      system_node.put("wacn", int_to_hex(stat_node.get<int>("wacn"), 0));
+      system_node.put("nac", int_to_hex(stat_node.get<int>("nac"), 0));
 
       systems_node.push_back(std::make_pair("", system_node));
     }
@@ -355,11 +350,11 @@ public:
     system_node.put("sys_num", stat_node.get<std::string>("id"));
     system_node.put("sys_name", stat_node.get<std::string>("name"));
     system_node.put("type", stat_node.get<std::string>("type"));
-    system_node.put("sysid", int_to_hex(stat_node.get<int>("sysid"),0));
-    system_node.put("wacn", int_to_hex(stat_node.get<int>("wacn"),0));
-    system_node.put("nac", int_to_hex(stat_node.get<int>("nac"),0));
+    system_node.put("sysid", int_to_hex(stat_node.get<int>("sysid"), 0));
+    system_node.put("wacn", int_to_hex(stat_node.get<int>("wacn"), 0));
+    system_node.put("nac", int_to_hex(stat_node.get<int>("nac"), 0));
 
-    // Resend the full system list with each update 
+    // Resend the full system list with each update
     setup_systems(this->systems);
 
     return send_object(system_node, "system", "system", this->topic, false);
@@ -373,17 +368,18 @@ public:
     // MQTT: topic/calls_active
     //   Send the list of all active calls; use a pointer to allow
     //   updates between the normal API calls
-    
+
     // Reset a pointer to the active call list if needed later
     this->tr_calls = calls;
     this->tr_calls_set = true;
-    
+
     boost::property_tree::ptree calls_node;
 
     for (std::vector<Call *>::iterator it = calls.begin(); it != calls.end(); ++it)
     {
       Call *call = *it;
-      if ( (call->get_current_length() > 0) || (!call->is_conventional()) ) {
+      if ((call->get_current_length() > 0) || (!call->is_conventional()))
+      {
         boost::property_tree::ptree stat_node = call->get_stats();
         boost::property_tree::ptree call_node;
 
@@ -399,10 +395,10 @@ public:
         call_node.put("elapsed", stat_node.get<std::string>("elapsed"));
         call_node.put("length", round_to_str(stat_node.get<double>("length")));
         call_node.put("call_state", stat_node.get<std::string>("state"));
-        call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]); 
+        call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]);
         call_node.put("mon_state", stat_node.get<std::string>("monState"));
         call_node.put("mon_state_type", mon_state[stat_node.get<int>("monState")]);
-        
+
         call_node.put("phase2", stat_node.get<std::string>("phase2"));
         call_node.put("conventional", stat_node.get<std::string>("conventional"));
         call_node.put("encrypted", stat_node.get<std::string>("encrypted"));
@@ -410,11 +406,12 @@ public:
         call_node.put("stop_time", stat_node.get<std::string>("stopTime"));
 
         // Not all calls have recorder info
-        if (stat_node.count("recNum")) {
+        if (stat_node.count("recNum"))
+        {
           call_node.put("rec_num", stat_node.get<std::string>("recNum"));
           call_node.put("src_num", stat_node.get<std::string>("srcNum"));
           call_node.put("rec_state", stat_node.get<std::string>("recState"));
-          call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]); 
+          call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]);
           call_node.put("analog", stat_node.get<std::string>("analog"));
         }
 
@@ -443,12 +440,12 @@ public:
       rec_node.put("rec_num", stat_node.get<std::string>("recNum"));
       rec_node.put("type", stat_node.get<std::string>("type"));
       rec_node.put("duration", round_to_str(stat_node.get<double>("duration")));
-      rec_node.put("freq", recorder->get_freq()); 
+      rec_node.put("freq", recorder->get_freq());
       rec_node.put("count", stat_node.get<std::string>("count"));
       rec_node.put("rec_state", stat_node.get<std::string>("state"));
-      rec_node.put("rec_state_type", tr_state[stat_node.get<int>("state")]); 
+      rec_node.put("rec_state_type", tr_state[stat_node.get<int>("state")]);
 
-      recs_node.push_back(std::make_pair("", rec_node)); 
+      recs_node.push_back(std::make_pair("", rec_node));
     }
 
     return send_object(recs_node, "recorders", "recorders", this->topic, false);
@@ -461,7 +458,7 @@ public:
 
     // MQTT: topic/recorder
     //   Send updates on individual recorders
-    
+
     boost::property_tree::ptree stat_node = recorder->get_stats();
     boost::property_tree::ptree rec_node;
 
@@ -473,7 +470,7 @@ public:
     rec_node.put("duration", round_to_str(stat_node.get<double>("duration")));
     rec_node.put("count", stat_node.get<std::string>("count"));
     rec_node.put("rec_state", stat_node.get<std::string>("state"));
-    rec_node.put("rec_state_type", tr_state[stat_node.get<int>("state")]); 
+    rec_node.put("rec_state_type", tr_state[stat_node.get<int>("state")]);
 
     return send_object(rec_node, "recorder", "recorder", this->topic, false);
   }
@@ -491,24 +488,24 @@ public:
     long talkgroup_num = call->get_talkgroup();
     long source_id = call->get_current_source_id();
     std::string short_name = call->get_short_name();
-    
+
     if ((this->unit_enabled))
     {
       boost::property_tree::ptree call_node;
       std::string patch_string = patches_to_str(call->get_system()->get_talkgroup_patch(talkgroup_num));
 
       call_node.put("sys_num", call->get_system()->get_sys_num());
-      call_node.put("sys_name", short_name );
+      call_node.put("sys_name", short_name);
       call_node.put("call_num", call->get_call_num());
       call_node.put("start_time", call->get_start_time());
       call_node.put("freq", call->get_freq());
-      call_node.put("unit", source_id );
+      call_node.put("unit", source_id);
       call_node.put("unit_alpha_tag", call->get_system()->find_unit_tag(source_id));
       call_node.put("talkgroup", talkgroup_num);
       call_node.put("talkgroup_alpha_tag", call->get_talkgroup_tag());
       call_node.put("talkgroup_patches", patch_string);
       call_node.put("encrypted", call->get_encrypted());
-      send_object(call_node, "call", "call", this->unit_topic+"/"+short_name, false);
+      send_object(call_node, "call", "call", this->unit_topic + "/" + short_name, false);
     }
 
     boost::property_tree::ptree stat_node = call->get_stats();
@@ -526,10 +523,10 @@ public:
     call_node.put("elapsed", stat_node.get<std::string>("elapsed"));
     call_node.put("length", round_to_str(stat_node.get<double>("length")));
     call_node.put("call_state", stat_node.get<std::string>("state"));
-    call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]); 
+    call_node.put("call_state_type", tr_state[stat_node.get<int>("state")]);
     call_node.put("mon_state", stat_node.get<std::string>("monState"));
     call_node.put("mon_state_type", mon_state[stat_node.get<int>("monState")]);
-    
+
     call_node.put("phase2", stat_node.get<std::string>("phase2"));
     call_node.put("conventional", stat_node.get<std::string>("conventional"));
     call_node.put("encrypted", stat_node.get<std::string>("encrypted"));
@@ -537,11 +534,12 @@ public:
     call_node.put("stop_time", stat_node.get<std::string>("stopTime"));
 
     // Not all calls have recorder info
-    if (stat_node.count("recNum")) {
+    if (stat_node.count("recNum"))
+    {
       call_node.put("rec_num", stat_node.get<std::string>("recNum"));
       call_node.put("src_num", stat_node.get<std::string>("srcNum"));
       call_node.put("rec_state", stat_node.get<std::string>("recState"));
-      call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]); 
+      call_node.put("rec_state_type", tr_state[stat_node.get<int>("recState")]);
       call_node.put("analog", stat_node.get<std::string>("analog"));
     }
 
@@ -557,7 +555,7 @@ public:
     //   Send information about a completed call.
     // MQTT: unit_topic/shortname/end
     //   Send information on participataing units.
-    //   This enables the collection unit information in conventional systems 
+    //   This enables the collection unit information in conventional systems
     //   without a control channel.
 
     // Generate list of talkgroup patches
@@ -569,8 +567,8 @@ public:
       // source_list[] can be used to suppliment transmission_list[] info
       std::vector<Call_Source> source_list = call_info.transmission_source_list;
       int transmision_num = 0;
-      
-      BOOST_FOREACH (auto& transmission, call_info.transmission_list)
+
+      BOOST_FOREACH (auto &transmission, call_info.transmission_list)
       {
         end_node.put("call_num", call_info.call_num);
         end_node.put("sys_name", call_info.short_name);
@@ -587,53 +585,53 @@ public:
         end_node.put("call_filename", call_info.filename);
         end_node.put("position", round_to_str(source_list[transmision_num].position));
         end_node.put("talkgroup", call_info.talkgroup);
-        end_node.put("talkgroup_alpha_tag",call_info.talkgroup_alpha_tag);
-        end_node.put("talkgroup_description",call_info.talkgroup_description);
-        end_node.put("talkgroup_group",call_info.talkgroup_group);
+        end_node.put("talkgroup_alpha_tag", call_info.talkgroup_alpha_tag);
+        end_node.put("talkgroup_description", call_info.talkgroup_description);
+        end_node.put("talkgroup_group", call_info.talkgroup_group);
         end_node.put("talkgroup_patches", patch_string);
         end_node.put("encrypted", call_info.encrypted);
         end_node.put("emergency", source_list[transmision_num].emergency);
         end_node.put("signal_system", source_list[transmision_num].signal_system);
-        
-        send_object(end_node, "end", "end", this->unit_topic+"/"+call_info.short_name.c_str(), false);
+
+        send_object(end_node, "end", "end", this->unit_topic + "/" + call_info.short_name.c_str(), false);
         transmision_num++;
       }
     }
     boost::property_tree::ptree call_node;
-    call_node.put("call_num",call_info.call_num);
-    call_node.put("sys_name",call_info.short_name);
-    call_node.put("start_time",call_info.start_time);
-    call_node.put("stop_time",call_info.stop_time);
-    call_node.put("length",round_to_str(call_info.length));
-    call_node.put("process_call_time",call_info.process_call_time);
-    call_node.put("retry_attempt",call_info.retry_attempt);
-    call_node.put("error_count",call_info.error_count);
-    call_node.put("spike_count",call_info.spike_count);
-    call_node.put("freq",call_info.freq);
-    call_node.put("encrypted",call_info.encrypted);
-    call_node.put("emergency",call_info.emergency);
-    call_node.put("tdma_slot",call_info.tdma_slot);
-    call_node.put("phase2_tdma",call_info.phase2_tdma);
-    call_node.put("talkgroup",call_info.talkgroup);
-    call_node.put("talkgroup_tag",call_info.talkgroup_tag);
-    call_node.put("talkgroup_alpha_tag",call_info.talkgroup_alpha_tag);
-    call_node.put("talkgroup_description",call_info.talkgroup_description);
-    call_node.put("talkgroup_group",call_info.talkgroup_group);
+    call_node.put("call_num", call_info.call_num);
+    call_node.put("sys_name", call_info.short_name);
+    call_node.put("start_time", call_info.start_time);
+    call_node.put("stop_time", call_info.stop_time);
+    call_node.put("length", round_to_str(call_info.length));
+    call_node.put("process_call_time", call_info.process_call_time);
+    call_node.put("retry_attempt", call_info.retry_attempt);
+    call_node.put("error_count", call_info.error_count);
+    call_node.put("spike_count", call_info.spike_count);
+    call_node.put("freq", call_info.freq);
+    call_node.put("encrypted", call_info.encrypted);
+    call_node.put("emergency", call_info.emergency);
+    call_node.put("tdma_slot", call_info.tdma_slot);
+    call_node.put("phase2_tdma", call_info.phase2_tdma);
+    call_node.put("talkgroup", call_info.talkgroup);
+    call_node.put("talkgroup_tag", call_info.talkgroup_tag);
+    call_node.put("talkgroup_alpha_tag", call_info.talkgroup_alpha_tag);
+    call_node.put("talkgroup_description", call_info.talkgroup_description);
+    call_node.put("talkgroup_group", call_info.talkgroup_group);
     call_node.put("talkgroup_patches", patch_string);
-    call_node.put("audio_type",call_info.audio_type);
+    call_node.put("audio_type", call_info.audio_type);
 
-    //call_node.put("status",call_info.status);
-    //call_node.put("transmission_list",call_info.transmission_list);
-    //call_node.put("upload_script",call_info.upload_script = sys->get_upload_script();
-    //call_node.put("audio_archive",call_info.audio_archive = sys->get_audio_archive();
-    //call_node.put("transmission_archive",call_info.transmission_archive = sys->get_transmission_archive();
-    //call_node.put("call_log",call_info.call_log = sys->get_call_log();
-    //call_node.put("compress_wav",call_info.compress_wav);
-    //call_node.put("talkgroup_display",call_info.talkgroup_display = call->get_talkgroup_display();
-    //call_info.min_transmissions_removed = 0;
-    //call_node.put("transmission_source_list",call_info.transmission_source_list);
-    //call_node.put("transmission_error_list",call_info.transmission_error_list);
-    
+    // call_node.put("status",call_info.status);
+    // call_node.put("transmission_list",call_info.transmission_list);
+    // call_node.put("upload_script",call_info.upload_script = sys->get_upload_script();
+    // call_node.put("audio_archive",call_info.audio_archive = sys->get_audio_archive();
+    // call_node.put("transmission_archive",call_info.transmission_archive = sys->get_transmission_archive();
+    // call_node.put("call_log",call_info.call_log = sys->get_call_log();
+    // call_node.put("compress_wav",call_info.compress_wav);
+    // call_node.put("talkgroup_display",call_info.talkgroup_display = call->get_talkgroup_display();
+    // call_info.min_transmissions_removed = 0;
+    // call_node.put("transmission_source_list",call_info.transmission_source_list);
+    // call_node.put("transmission_error_list",call_info.transmission_error_list);
+
     // Some stats are rounded to prevent long/repeating floats
     return send_object(call_node, "call", "call_end", this->topic, false);
   }
@@ -652,10 +650,10 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
 
-      return send_object(unit_node, "on", "on", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "on", "on", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -674,10 +672,10 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
 
-      return send_object(unit_node, "off", "off", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "off", "off", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -696,10 +694,10 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
 
-      return send_object(unit_node, "ackresp", "ackresp", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "ackresp", "ackresp", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -719,7 +717,7 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
       unit_node.put("talkgroup", talkgroup_num);
       Talkgroup *tg = sys->find_talkgroup(talkgroup_num);
@@ -729,7 +727,7 @@ public:
       }
       unit_node.put("talkgroup_patches", patch_string);
 
-      return send_object(unit_node, "join", "join", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "join", "join", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -748,10 +746,10 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
-      
-      return send_object(unit_node, "data", "data", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+
+      return send_object(unit_node, "data", "data", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -770,7 +768,7 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha_tag", sys->find_unit_tag(source_id));
       unit_node.put("talkgroup", talkgroup);
       Talkgroup *tg = sys->find_talkgroup(talkgroup);
@@ -779,7 +777,7 @@ public:
         unit_node.put("talkgroup_alpha_tag", tg->alpha_tag);
       }
 
-      return send_object(unit_node, "ans_req", "ans_req", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "ans_req", "ans_req", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
@@ -799,7 +797,7 @@ public:
 
       unit_node.put("sys_num", sys->get_sys_num());
       unit_node.put("sys_name", sys->get_short_name());
-      unit_node.put("unit", source_id );
+      unit_node.put("unit", source_id);
       unit_node.put("unit_alpha", sys->find_unit_tag(source_id));
       unit_node.put("talkgroup", talkgroup_num);
       Talkgroup *tg = sys->find_talkgroup(talkgroup_num);
@@ -808,11 +806,10 @@ public:
         unit_node.put("talkgroup_alpha_tag", tg->alpha_tag);
       }
       unit_node.put("talkgroup_patches", patch_string);
-      return send_object(unit_node, "location", "location", this->unit_topic+"/"+sys->get_short_name().c_str(), false);
+      return send_object(unit_node, "location", "location", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
     return 1;
   }
-
 
   // ********************************
   // trunk-recorder plugin API & startup
@@ -822,7 +819,7 @@ public:
   {
     // TRUNK-RECORDER PLUGIN API
     //   Called before init(); parses the config information for this plugin.
-    
+
     this->mqtt_broker = cfg.get<std::string>("broker", "tcp://localhost:1883");
     this->client_id = cfg.get<std::string>("client_id", "tr-status");
     this->username = cfg.get<std::string>("username", "");
@@ -832,16 +829,16 @@ public:
 
     this->unit_topic = cfg.get<std::string>("unit_topic", "");
     if (this->unit_topic != "")
-      this->unit_enabled = true;        
+      this->unit_enabled = true;
     else
-      this->unit_topic = "[disabled]";  
+      this->unit_topic = "[disabled]";
 
     this->message_topic = cfg.get<std::string>("message_topic", "");
     if (this->message_topic != "")
       this->message_enabled = true;
-    else  
+    else
       this->message_topic = "[disabled]";
-    
+
     // Remove any trailing slashes from topics
     if (this->topic.back() == '/')
       this->topic.erase(this->topic.size() - 1);
@@ -856,7 +853,7 @@ public:
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker: " << this->mqtt_broker;
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Client Name: " << this->client_id;
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker Username: " << this->username;
-    if (this->password != "" )
+    if (this->password != "")
       BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker Password: ********";
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Topic: " << this->topic;
     BOOST_LOG_TRIVIAL(info) << " MQTT Unit Status Plugin Topic: " << this->unit_topic;
@@ -874,8 +871,8 @@ public:
     frequency_format = config->frequency_format;
     this->instance_id = config->instance_id;
     if (this->instance_id == "")
-       this->instance_id = "trunk-recorder";
-    
+      this->instance_id = "trunk-recorder";
+
     // Establish pointers to systems, sources, and configs if needed later.
     this->sources = sources;
     this->systems = systems;
@@ -904,7 +901,8 @@ public:
     // TRUNK-RECORDER PLUGIN API
     //   Called at the same periodicity of system_rates(), this can be use to accomplish
     //   occasional plugin tasks more efficiently than checking each cycle of poll_one().
-    
+
+    // Refresh recorders every 3 seconds
     resend_recorders();
 
     return 0;
@@ -915,17 +913,17 @@ public:
     // TRUNK-RECORDER PLUGIN API
     //   Called during each pass through the main loop of trunk-recorder.
 
+    // Refresh calls every 1 second
     resend_calls();
 
     return 0;
   }
 
-
   // ********************************
   // Helper functions
   // ********************************
 
-  int resend_recorders()
+  void resend_recorders()
   {
     // Periodically update the status of all recorders.
     // Triggered by setup_config() every 3 seconds.
@@ -938,24 +936,20 @@ public:
       recorders.insert(recorders.end(), sourceRecorders.begin(), sourceRecorders.end());
     }
     send_recorders(recorders);
-
-    return 0;
   }
 
-  int resend_calls()
+  void resend_calls()
   {
     // Use a pointer from calls_active() to update the active call list once a second.
     // Triggered by poll_one().
 
     time_t now_time = time(NULL);
 
-    if (((now_time - this->call_resend_time ) >= 1 ))
+    if (((now_time - this->call_resend_time) >= 1))
     {
       calls_active(this->tr_calls);
       this->call_resend_time = now_time;
     }
-    
-    return 0;
   }
 
   std::string int_to_hex(int num, int places)
@@ -963,7 +957,7 @@ public:
     // Return a hexidecimal value for a given integer, zero-padded for "places"
 
     std::stringstream stream;
-    stream << std::setfill ('0') << std::uppercase << std::setw(places) << std::hex << num;
+    stream << std::setfill('0') << std::uppercase << std::setw(places) << std::hex << num;
     std::string result(stream.str());
     return result;
   }
@@ -983,17 +977,15 @@ public:
     // Combine a vector of talkgroup patches into a string.
 
     std::string patch_string;
-    bool first = true;
 
-    BOOST_FOREACH (auto& TGID, talkgroup_patches)
+    BOOST_FOREACH (auto &TGID, talkgroup_patches)
     {
-      if (!first) { patch_string += ","; }
-      first = false;
+      if (!patch_string.empty())
+        patch_string += ",";
       patch_string += std::to_string(TGID);
     }
     return patch_string;
   }
-
 
   // ********************************
   // Paho MQTT
@@ -1002,12 +994,12 @@ public:
   void open_connection()
   {
     // Open the connection to the destination MQTT server using paho libraries.
-    
+
     // Set a connect/disconnect message between client and broker
     std::stringstream connect_json;
     std::stringstream lwt_json;
     std::string status_topic = this->topic + "/trunk_recorder/" + this->client_id;
-    
+
     boost::property_tree::ptree status;
     status.put("status", "connected");
     status.put("instance_id", this->instance_id);
@@ -1017,28 +1009,28 @@ public:
     boost::property_tree::write_json(lwt_json, status);
 
     mqtt::message_ptr conn_msg = mqtt::message_ptr_builder()
-      .topic(status_topic)
-      .payload(connect_json.str())
-      .qos(this->qos)
-      .retained(true)
-      .finalize();
+                                     .topic(status_topic)
+                                     .payload(connect_json.str())
+                                     .qos(this->qos)
+                                     .retained(true)
+                                     .finalize();
 
     std::string lwt_string = lwt_json.str();
     auto will_msg = mqtt::message(status_topic, lwt_string.c_str(), strlen(lwt_string.c_str()), this->qos, true);
 
     // Set SSL options
-    mqtt::ssl_options sslopts =  mqtt::ssl_options_builder()
-      .verify(false)
-      .enable_server_cert_auth(false)
-      .finalize();
+    mqtt::ssl_options sslopts = mqtt::ssl_options_builder()
+                                    .verify(false)
+                                    .enable_server_cert_auth(false)
+                                    .finalize();
 
     // Set connection options
     mqtt::connect_options connOpts = mqtt::connect_options_builder()
-      .clean_session()
-      .ssl(sslopts)
-      .automatic_reconnect(std::chrono::seconds(10), std::chrono::seconds(40))
-      .will(will_msg)
-      .finalize();
+                                         .clean_session()
+                                         .ssl(sslopts)
+                                         .automatic_reconnect(std::chrono::seconds(10), std::chrono::seconds(40))
+                                         .will(will_msg)
+                                         .finalize();
 
     // Set user/pass if indicated
     if ((this->username != "") && (this->password != ""))
@@ -1080,7 +1072,7 @@ public:
     // Ignore requests to send MQTT messages before the connection is opened
     if (m_open == false)
       return 0;
-  
+
     // Build the MQTT payload, add addtional keys [timestamp, instance_id]
     boost::property_tree::ptree payload;
     payload.add_child(name, data);
@@ -1093,12 +1085,12 @@ public:
 
     // Assemble the MQTT message
     mqtt::message_ptr pubmsg = mqtt::message_ptr_builder()
-      .topic(object_topic + "/" + type)
-      .payload(payload_json.str())
-      .qos(this->qos)
-      .retained(retained)
-      .finalize();
-    
+                                   .topic(object_topic + "/" + type)
+                                   .payload(payload_json.str())
+                                   .qos(this->qos)
+                                   .retained(retained)
+                                   .finalize();
+
     // Publish the MQTT message
     try
     {
@@ -1106,23 +1098,22 @@ public:
     }
     catch (const mqtt::exception &exc)
     {
-      BOOST_LOG_TRIVIAL(error) << "MQTT Status Plugin - " <<exc.what() << endl;
+      BOOST_LOG_TRIVIAL(error) << "MQTT Status Plugin - " << exc.what() << endl;
     }
 
-    return 0;
+    return 1;
   }
 
   // Paho mqtt::iaction_listeners.  Required, but not used.
-  void on_failure(const mqtt::token &tok) override {};
-  void on_success(const mqtt::token &tok) override {};
-  
+  void on_failure(const mqtt::token &tok) override{};
+  void on_success(const mqtt::token &tok) override{};
+
   // Paho mqtt::callbacks.
   void connection_lost(const string &cause) override
   {
     // Paho MQTT: This method is called when the connection to the server is lost.
     BOOST_LOG_TRIVIAL(error) << "MQTT Status Plugin - Connection lost to: " << this->mqtt_broker << "/tcause: " << cause;
   }
-
 
   // ********************************
   // Create the plugin

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -1,3 +1,8 @@
+// MQTT Status and Unit Plugin for Trunk-Recorder
+// ********************************
+// Requires trunk-recorder 4.5; commit 17 MAY 2023 (5c07ef0) or later for trunk_message() API
+// ********************************
+
 #include <time.h>
 #include <vector>
 
@@ -160,7 +165,7 @@ public:
     //   Sent on each trunking message
 
     // MQTT: message_topic/short_name
-    //   Lay the groundwork for trunk_message!
+    //   Display an overview of recieved trunk messages.
 
     if ((this->message_enabled))
     {
@@ -177,7 +182,7 @@ public:
         message_node.put("opcode_type", opcode_type[message.opcode][0]);
         message_node.put("opcode_desc", opcode_type[message.opcode][1]);
 
-        return send_object(message_node, "message", system->get_short_name().c_str(), this->message_topic, false);
+        return send_object(message_node, "message", "message", this->message_topic + "/" + system->get_short_name().c_str(), false);
       }
     }
     return 0;
@@ -651,6 +656,7 @@ public:
 
       return send_object(unit_node, "on", "on", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -673,6 +679,7 @@ public:
 
       return send_object(unit_node, "off", "off", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -695,6 +702,7 @@ public:
 
       return send_object(unit_node, "ackresp", "ackresp", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -725,6 +733,7 @@ public:
 
       return send_object(unit_node, "join", "join", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -747,6 +756,7 @@ public:
 
       return send_object(unit_node, "data", "data", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -775,6 +785,7 @@ public:
 
       return send_object(unit_node, "ans_req", "ans_req", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -804,6 +815,7 @@ public:
       unit_node.put("talkgroup_patches", patch_string);
       return send_object(unit_node, "location", "location", this->unit_topic + "/" + sys->get_short_name().c_str(), false);
     }
+
     return 0;
   }
 
@@ -955,6 +967,7 @@ public:
     std::stringstream stream;
     stream << std::setfill('0') << std::uppercase << std::setw(places) << std::hex << num;
     std::string result(stream.str());
+    
     return result;
   }
 
@@ -965,6 +978,7 @@ public:
 
     char rounded[20];
     snprintf(rounded, sizeof(rounded), "%.2f", num);
+    
     return std::string(rounded);
   }
 
@@ -980,6 +994,7 @@ public:
         patch_string += ",";
       patch_string += std::to_string(TGID);
     }
+    
     return patch_string;
   }
 


### PR DESCRIPTION
- Rename many of the MQTT keys for consistency between messages
- Update documentation internal documentation, and on github
- Provide a full list of example MQTT messages, as well as any changes since the original plugin and community fork